### PR TITLE
gitignore tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-/Platformer/Platformer/bin/
-/Platformer/Platformer/obj/
-/Platformer/.vs/
+bin
+obj
+\.vs
+\.idea
+*.DotSettings.*


### PR DESCRIPTION
Ignoring Rider-specific folder. `bin` and `obj` generalized